### PR TITLE
fix: `conceallevel` fix, annotations, `vim.validate` usage

### DIFF
--- a/lua/hoversplit/config.lua
+++ b/lua/hoversplit/config.lua
@@ -1,8 +1,13 @@
+---@class HoverSplit.Config
 local M = {}
 
+---@class HoverSplit.Opts
 M.options = {
+	---@type 0|1|2|3
 	conceallevel = 3,
+	---@type boolean
 	key_bindings_disabled = false,
+	---@type { split: string, vsplit: string, split_remain_focused: string, vsplit_remain_focused: string }
 	key_bindings = {
 		split = "<leader>hS",
 		vsplit = "<leader>hV",

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -108,7 +108,7 @@ function M.create_hover_split(vertical, remain_focused)
 		win_opts.split = "below"
 	end
 
-	local conceallevel = config.conceallevel or 3
+	local conceallevel = config.options.conceallevel or 3
 	conceallevel = vim.list_contains({ 0, 1, 2, 3 }, conceallevel) and conceallevel or 3
 	M.hover_winid = vim.api.nvim_open_win(M.hover_bufnr, M.remain_focused, win_opts)
 	vim.api.nvim_win_set_buf(M.hover_winid, M.hover_bufnr)

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -10,6 +10,11 @@ M.orig_bufnr = nil ---@type integer|nil
 ---@param bufnr? integer
 ---@return boolean
 function M.check_hover_support(bufnr)
+	if vim.fn.has("nvim-0.11") then
+		vim.validate("bufnr", bufnr, "number", true)
+	else
+		vim.validate({ bufnr = { bufnr, { "number", "nil" } } })
+	end
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 	if bufnr == M.hover_bufnr then
 		return false
@@ -157,6 +162,11 @@ function M.close_hover_split()
 end
 
 function M.setup(options)
+	if vim.fn.has("nvim-0.11") then
+		vim.validate("options", options, "table", true, "HoverSplit.Opts")
+	else
+		vim.validate({ options = { options, { "table", "nil" } } })
+	end
 	options = options or {}
 	config.options = vim.tbl_deep_extend("force", config.options, options)
 

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -1,3 +1,4 @@
+---@class HoverSplit
 local M = {}
 
 local config = require("hoversplit.config")
@@ -161,6 +162,7 @@ function M.close_hover_split()
 	end
 end
 
+---@param options? HoverSplit.Opts
 function M.setup(options)
 	if vim.fn.has("nvim-0.11") then
 		vim.validate("options", options, "table", true, "HoverSplit.Opts")


### PR DESCRIPTION
## Changes

- Added `vim.validate` checks in certain functions
- `conceallevel` option was used incorrectly
- Added [LuaLS type annotations](https://luals.github.io/wiki/annotations/)