### PR TITLE
feat: update content on LSP progress

### DIFF
--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -118,9 +118,9 @@ function M.create_hover_split(vertical, remain_focused)
 
 	vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI", "LspProgress" }, {
 		group = augroup,
-		callback = function()
-			if vim.api.nvim_get_current_win() ~= M.hover_winid then
-				if M.check_hover_support(vim.api.nvim_get_current_buf()) then
+		callback = function(args)
+			if args.buf ~= M.hover_bufnr then
+				if M.check_hover_support(args.buf) then
 					M.update_hover_content()
 				end
 			end

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -116,11 +116,11 @@ function M.create_hover_split(vertical, remain_focused)
 	vim.wo[M.hover_winid].wrap = true
 	vim.wo[M.hover_winid].conceallevel = conceallevel
 
-	vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+	vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI", "LspProgress" }, {
 		group = augroup,
-		callback = function(args)
-			if args.buf ~= M.hover_bufnr then
-				if M.check_hover_support(args.buf) then
+		callback = function()
+			if vim.api.nvim_get_current_win() ~= M.hover_winid then
+				if M.check_hover_support(vim.api.nvim_get_current_buf()) then
 					M.update_hover_content()
 				end
 			end


### PR DESCRIPTION
In case when LSP not loaded yet hoversplit will stay with "LSP progress 237/3985" until cursor moved, this PR aims to fix this behavior by trigerring content update on LspProgress event