### PR TITLE
feat: handle hoversplit close more gracefully

### DIFF
--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -131,6 +131,10 @@ function M.create_hover_split(vertical, remain_focused)
 	vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
 		group = augroup,
 		callback = function(args)
+			-- Unregister autocmd if hover buffer does not exists
+    		if not (M.hover_bufnr and M.hover_winid) then -- Condition expands to `not M.hover_bufnr or not M.hover_winid`
+				return true
+			end
 			if args.buf ~= M.hover_bufnr then
 				if M.check_hover_support(args.buf) then
 					M.update_hover_content()
@@ -181,7 +185,6 @@ function M.close_hover_split()
 	end
 	M.hover_bufnr = nil
 	M.hover_winid = nil
-	vim.api.nvim_create_augroup("HoverSplit", { clear = true })
 end
 
 function M.setup(options)

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -131,7 +131,9 @@ function M.create_hover_split(vertical, remain_focused)
 		group = augroup,
 		callback = function(args)
 			if args.buf == M.hover_bufnr then
-				M.close_hover_split()
+				vim.schedule(M.close_hover_split)
+
+				return true
 			end
 		end,
 	})

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -48,6 +48,10 @@ function M.update_hover_content()
 				return
 			end
 
+			if not M.hover_bufnr or not vim.api.nvim_buf_is_valid(M.hover_bufnr) then
+				return
+			end
+
 			local lines = vim.lsp.util.convert_input_to_markdown_lines(result.contents)
 			vim.bo[M.hover_bufnr].modifiable = true
 			vim.api.nvim_buf_set_lines(M.hover_bufnr, 0, -1, false, lines)

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -165,7 +165,7 @@ function M.close_hover_split()
 	end
 	M.hover_bufnr = nil
 	M.hover_winid = nil
-	vim.api.nvim_del_augroup_by_name("HoverSplit")
+	vim.api.nvim_create_augroup("HoverSplit", { clear = true })
 end
 
 function M.setup(options)

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -129,8 +129,8 @@ function M.create_hover_split(vertical, remain_focused)
 
 	vim.api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
 		group = augroup,
-		callback = function(bufnr)
-			if bufnr == M.hover_bufnr then
+		callback = function(args)
+			if args.buf == M.hover_bufnr then
 				M.close_hover_split()
 			end
 		end,

--- a/lua/hoversplit/init.lua
+++ b/lua/hoversplit/init.lua
@@ -127,6 +127,15 @@ function M.create_hover_split(vertical, remain_focused)
 		end,
 	})
 
+	vim.api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
+		group = augroup,
+		callback = function(bufnr)
+			if bufnr == M.hover_bufnr then
+				M.close_hover_split()
+			end
+		end,
+	})
+
 	if vim.api.nvim_get_current_win() ~= M.hover_winid then
 		M.update_hover_content()
 	end
@@ -151,9 +160,10 @@ end
 function M.close_hover_split()
 	if M.hover_bufnr and vim.api.nvim_buf_is_valid(M.hover_bufnr) then
 		vim.api.nvim_buf_delete(M.hover_bufnr, { force = true })
-		M.hover_bufnr = nil
-		M.hover_winid = nil
 	end
+	M.hover_bufnr = nil
+	M.hover_winid = nil
+	vim.api.nvim_del_augroup_by_name("HoverSplit")
 end
 
 function M.setup(options)


### PR DESCRIPTION
This PR aims to close hoversplit window more gracefully by:
- handling BufDelete/BufWipeout events in case when hoversplit was closed by someone else (for example edgy.nvim in my case)
- removing autogroup on close to prevent events processing which are still called after hoversplit closed